### PR TITLE
chore: refresh actor metadata for phase 2

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -1,9 +1,9 @@
 {
   "actorSpecVersion": 1,
   "name": "grail-hunter",
-  "title": "Grail Hunter - Multi-Platform Sneaker Monitor",
-  "description": "Aggregates sneaker listings from eBay, Grailed, StockX, and GOAT. Delivers real-time alerts when target sneakers appear with intelligent parsing and deduplication.",
-  "version": "0.1.0",
+  "title": "Grail Hunter - Phase 2 Multi-Platform Monitor",
+  "description": "Aggregates sneaker listings from Grailed and eBay with intelligent parsing, deduplication, and real-time alerts. Future phases will add StockX and GOAT.",
+  "version": "0.2.0",
   "author": {
     "name": "Beaulewis1977",
     "email": "support@grailhunter.app"

--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -1,6 +1,6 @@
 {
-  "title": "Grail Hunter - Phase 1: Grailed MVP",
-  "description": "Search Grailed for sneakers and get notified about new listings",
+  "title": "Grail Hunter - Phase 2: Grailed & eBay",
+  "description": "Monitor Grailed and eBay for new sneaker listings and get real-time alerts.",
   "type": "object",
   "schemaVersion": 1,
   "properties": {
@@ -62,18 +62,18 @@
       "default": "used_good"
     },
     "platform": {
-      "title": "Platform",
+      "title": "Legacy Single Platform",
       "type": "string",
-      "description": "⚠️ Phase 1 only supports Grailed. More platforms coming in future phases!",
+      "description": "Backward-compatible single-platform selector (defaults to Grailed). Use the Platforms list below for Phase 2 multi-platform runs.",
       "editor": "select",
       "enum": ["grailed"],
-      "enumTitles": ["Grailed (✅ Available)"],
+      "enumTitles": ["Grailed"],
       "default": "grailed"
     },
     "platforms": {
-      "title": "Platforms (Phase 2)",
+      "title": "Platforms",
       "type": "array",
-      "description": "Select one or more platforms to search (Phase 2). Leave empty to use the single 'platform' field.",
+      "description": "Select one or more platforms to search. Leave empty to fall back to the single 'Legacy Single Platform' field.",
       "editor": "select",
       "items": {
         "type": "string",


### PR DESCRIPTION
## Summary
- bump actor metadata to version 0.2.0 for Phase 2 launch
- align input schema copy with Grailed + eBay support

## Testing
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated product branding to Phase 2 Multi-Platform Monitor.
  * Version bumped to 0.2.0.
  * Updated product description to reflect current focus on Grailed and eBay monitoring with deduplication and real-time alerts.
  * Updated configuration schema and field descriptions for improved clarity on platform selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->