### PR TITLE
 feat(phase-41): Beta Platforms (Mercari & OfferUp) - Complete

### DIFF
--- a/.actor/actor.json
+++ b/.actor/actor.json
@@ -1,9 +1,9 @@
 {
   "actorSpecVersion": 1,
   "name": "grail-hunter",
-  "title": "Grail Hunter - Phase 2 Multi-Platform Monitor",
-  "description": "Aggregates sneaker listings from Grailed and eBay with intelligent parsing, deduplication, and real-time alerts. Future phases will add StockX and GOAT.",
-  "version": "0.2.0",
+  "title": "Grail Hunter - Phase 4.1: Beta Platforms (Mercari + OfferUp)",
+  "description": "Aggregates sneaker listings from 7 platforms (Grailed, eBay, StockX, Depop, Poshmark, Mercari, OfferUp) with intelligent parsing, deal scoring, price tracking, and real-time alerts. Beta platforms require explicit opt-in.",
+  "version": "0.4.1",
   "author": {
     "name": "Beaulewis1977",
     "email": "support@grailhunter.app"

--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -216,6 +216,14 @@
       "type": "boolean",
       "description": "Enable OfferUp scraping. Requires betaPlatformsEnabled=true and a US ZIP code for location-based search. WARNING: OfferUp uses Cloudflare protection and browser automation, which may be slow and fail frequently. Use at your own risk. Default: false.",
       "default": false
+    },
+    "zipCode": {
+      "title": "ZIP Code (for OfferUp)",
+      "type": "string",
+      "description": "US ZIP code for location-based search on OfferUp. Required when OfferUp is enabled. Format: 5-digit ZIP code (e.g., '10001' for NYC, '90210' for Beverly Hills). Defaults to 10001 (NYC) if not provided.",
+      "editor": "textfield",
+      "pattern": "^[0-9]{5}$",
+      "example": "10001"
     }
   },
   "required": ["keywords"]

--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -1,5 +1,5 @@
 {
-  "title": "Grail Hunter - Phase 4.0: Safer Marketplaces (Depop + Poshmark)",
+  "title": "Grail Hunter - Phase 4.1: Beta Platforms (Mercari + OfferUp)",
   "description": "Monitor 5 platforms (Grailed, eBay, StockX, Depop, Poshmark) for sneaker listings with deal scoring, price tracking, advanced filters, and real-time alerts.",
   "type": "object",
   "schemaVersion": 1,
@@ -73,12 +73,20 @@
     "platforms": {
       "title": "Platforms",
       "type": "array",
-      "description": "Select one or more platforms to search. Phase 4.0 added Depop and Poshmark as safer marketplace options. Leave empty to fall back to the single 'Legacy Single Platform' field.",
+      "description": "Select one or more platforms to search. Phase 4.0 added Depop and Poshmark as safer marketplaces. Phase 4.1 added Mercari and OfferUp as BETA platforms (requires betaPlatformsEnabled + per-platform toggles). Leave empty to fall back to the single 'Legacy Single Platform' field.",
       "editor": "select",
       "items": {
         "type": "string",
-        "enum": ["grailed", "ebay", "stockx", "depop", "poshmark"],
-        "enumTitles": ["Grailed", "eBay", "StockX (⚠️  HIGH RISK)", "Depop", "Poshmark"]
+        "enum": ["grailed", "ebay", "stockx", "depop", "poshmark", "mercari", "offerup"],
+        "enumTitles": [
+          "Grailed",
+          "eBay",
+          "StockX (⚠️  HIGH RISK)",
+          "Depop",
+          "Poshmark",
+          "Mercari (🧪 BETA)",
+          "OfferUp (🧪 BETA)"
+        ]
       },
       "uniqueItems": true
     },
@@ -189,6 +197,24 @@
       "title": "Enable StockX Scraping (⚠️  HIGH RISK)",
       "type": "boolean",
       "description": "WARNING: StockX actively enforces ToS. Scraping may result in IP blocks or legal action. Use at your own risk.",
+      "default": false
+    },
+    "betaPlatformsEnabled": {
+      "title": "Enable Beta Platforms (🧪 EXPERIMENTAL)",
+      "type": "boolean",
+      "description": "Global toggle to enable beta platforms (Mercari, OfferUp). Beta platforms have higher risk of blocking, anti-bot detection, and may fail more frequently. You must also enable individual beta platforms below. Default: false (disabled).",
+      "default": false
+    },
+    "enableMercari": {
+      "title": "Enable Mercari (🧪 BETA)",
+      "type": "boolean",
+      "description": "Enable Mercari scraping. Requires betaPlatformsEnabled=true. WARNING: Mercari has aggressive anti-bot measures and the underlying actor may be unreliable. Scraping may fail frequently. Use at your own risk. Default: false.",
+      "default": false
+    },
+    "enableOfferUp": {
+      "title": "Enable OfferUp (🧪 BETA)",
+      "type": "boolean",
+      "description": "Enable OfferUp scraping. Requires betaPlatformsEnabled=true and a US ZIP code for location-based search. WARNING: OfferUp uses Cloudflare protection and browser automation, which may be slow and fail frequently. Use at your own risk. Default: false.",
       "default": false
     }
   },

--- a/IMPLEMENTATION_STATUS.md
+++ b/IMPLEMENTATION_STATUS.md
@@ -15,9 +15,10 @@ Phase status:
   existing Grailed/eBay/StockX flows with advanced filters and sample presets. See details below.
 - **Phase 4.0 – Safer Marketplaces (Depop + Poshmark):** ✅ **COMPLETE** - Added Depop and Poshmark
   as safer platforms using orchestrated actors. See details below.
-- **Phase 4.1 – Beta Platforms (Mercari, OfferUp):** ⏳ **PLANNED** - Introduce Mercari and OfferUp
-  as opt-in beta platforms, controlled via `betaPlatformsEnabled`, `enableMercari`, and
-  `enableOfferUp`. See `audit/COVERAGE_ROADMAP.md` and `prompts/phase-41-agent-prompt.md`.
+- **Phase 4.1 – Beta Platforms (Mercari, OfferUp):** ✅ **COMPLETE** - Mercari and OfferUp added as
+  opt-in beta platforms, controlled via `betaPlatformsEnabled`, `enableMercari`, and `enableOfferUp`
+  toggles. Strict limits (30 max results, conservative retries), comprehensive tests, and graceful
+  degradation implemented. See `audit/COVERAGE_ROADMAP.md` and `prompts/phase-41-agent-prompt.md`.
 - **Phase 4.2 – GOAT & StockX Hybrid Intelligence:** ⏳ **PLANNED** - Implement GOAT/StockX using a
   hybrid of orchestrated actors (Pattern A) and dataset ingestion (Pattern C), with both platforms
   disabled by default and clearly documented as high risk. See `audit/COVERAGE_ROADMAP.md` and

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Grail Hunter monitors sneaker listings across multiple platforms in real-time:
 
 Grail Hunter monitors these major sneaker marketplaces:
 
-| Platform                  | Type          | Status       | Description                                   |
-| ------------------------- | ------------- | ------------ | --------------------------------------------- |
-| **eBay**                  | Marketplace   | ✅ Available | World's largest P2P marketplace               |
-| **Grailed**               | Marketplace   | ✅ Available | Premium streetwear and sneaker marketplace    |
-| **Depop**                 | Marketplace   | ✅ Available | Safer peer-to-peer marketplace (Phase 4.0)    |
-| **Poshmark**              | Marketplace   | ✅ Available | Safer peer-to-peer marketplace (Phase 4.0)    |
-| **StockX (⚠️ HIGH RISK)** | Authenticated | ⚠️ Optional  | Stock market for sneakers with authentication |
-| **GOAT (Planned)**        | Authenticated | 🚧 Phase 4.2 | Premium authenticated sneaker platform        |
+| Platform                  | Type          | Status       | Description                                          |
+| ------------------------- | ------------- | ------------ | ---------------------------------------------------- |
+| **eBay**                  | Marketplace   | ✅ Available | World's largest P2P marketplace                      |
+| **Grailed**               | Marketplace   | ✅ Available | Premium streetwear and sneaker marketplace           |
+| **Depop**                 | Marketplace   | ✅ Available | Safer peer-to-peer marketplace (Phase 4.0)           |
+| **Poshmark**              | Marketplace   | ✅ Available | Safer peer-to-peer marketplace (Phase 4.0)           |
+| **Mercari (🧪 BETA)**     | Marketplace   | 🧪 Beta      | Beta platform - requires explicit opt-in (Phase 4.1) |
+| **OfferUp (🧪 BETA)**     | Marketplace   | 🧪 Beta      | Beta platform - requires explicit opt-in (Phase 4.1) |
+| **StockX (⚠️ HIGH RISK)** | Authenticated | ⚠️ Optional  | Stock market for sneakers with authentication        |
+| **GOAT (Planned)**        | Authenticated | 🚧 Phase 4.2 | Premium authenticated sneaker platform               |
 
 > **⚠️ StockX WARNING**: StockX actively enforces their Terms of Service and uses advanced anti-bot
 > protection. Scraping may result in IP blocks or legal action. Use at your own risk and consider
@@ -794,7 +796,7 @@ grail-hunter/
 - ✅ **Phase 3:** StockX integration + market value benchmarking (Complete)
 - ✅ **Phase 3.x:** Advanced filters & monitoring (Complete)
 - ✅ **Phase 4.0:** Depop + Poshmark integration (Complete)
-- ⏳ **Phase 4.1:** Mercari + OfferUp (Beta platforms)
+- ✅ **Phase 4.1:** Mercari + OfferUp (Beta platforms - opt-in required)
 - ⏳ **Phase 4.2:** GOAT integration + hybrid intelligence
 
 See [IMPLEMENTATION_STATUS.md](./IMPLEMENTATION_STATUS.md) for detailed status and
@@ -948,5 +950,4 @@ For technical issues or questions:
 
 **Made with ❤️ for the sneaker community**
 
-**Status:** ✅ Phase 4.0 Complete (Safer Marketplaces: Depop + Poshmark) | ⏳ Phase 4.1-4.2 In
-Planning
+**Status:** ✅ Phase 4.1 Complete (Beta Platforms: Mercari + OfferUp) | ⏳ Phase 4.2 Next Planning

--- a/src/config/platforms.js
+++ b/src/config/platforms.js
@@ -72,6 +72,40 @@ export const PLATFORM_CONFIGS = {
     baseUrl: 'https://poshmark.com',
     riskLevel: 'low', // Safer marketplace
   },
+  // Phase 4.1: Beta Platforms (Higher Risk)
+  mercari: {
+    name: 'Mercari',
+    type: 'orchestrated',
+    actorId: 'jupri/mercari-scraper',
+    rateLimit: 50, // Conservative limit for beta platform
+    cacheTimeout: 15, // Shorter cache for beta
+    isAuthenticated: false,
+    requiresProxy: true,
+    enabled: false, // Disabled by default - beta platform
+    baseUrl: 'https://www.mercari.com',
+    riskLevel: 'medium-high', // Beta platform with anti-bot measures
+    isBeta: true,
+    maxResults: 30, // Strict limit for beta
+    timeoutMs: 120000, // 2 minute timeout
+    maxRetries: 2, // Conservative retry strategy
+  },
+  offerup: {
+    name: 'OfferUp',
+    type: 'orchestrated',
+    actorId: 'igolaizola/offerup-scraper',
+    rateLimit: 30, // Very conservative for Cloudflare protection
+    cacheTimeout: 15,
+    isAuthenticated: false,
+    requiresProxy: true,
+    enabled: false, // Disabled by default - beta platform
+    baseUrl: 'https://offerup.com',
+    riskLevel: 'medium-high', // Beta platform with Cloudflare
+    isBeta: true,
+    maxResults: 30, // Strict limit for beta
+    timeoutMs: 180000, // 3 minute timeout (browser automation is slower)
+    maxRetries: 2, // Conservative retry strategy
+    requiresZipCode: true, // OfferUp requires location-based search
+  },
 };
 
 export const SUPPORTED_PLATFORMS = Object.keys(PLATFORM_CONFIGS).filter(

--- a/src/config/platforms.js
+++ b/src/config/platforms.js
@@ -108,6 +108,7 @@ export const PLATFORM_CONFIGS = {
   },
 };
 
+// Export all platforms that are either enabled OR are beta platforms (beta platforms use explicit toggle-based validation)
 export const SUPPORTED_PLATFORMS = Object.keys(PLATFORM_CONFIGS).filter(
-  (key) => PLATFORM_CONFIGS[key].enabled !== false
+  (key) => PLATFORM_CONFIGS[key].enabled !== false || PLATFORM_CONFIGS[key].isBeta === true
 );

--- a/src/index.js
+++ b/src/index.js
@@ -20,9 +20,7 @@ import { PLATFORM_CONFIGS } from './config/platforms.js';
 import { ValidationError } from './utils/errors.js';
 
 Actor.main(async () => {
-  logger.info(
-    '🚀 Grail Hunter actor started - Phase 3: StockX Integration & Advanced Intelligence'
-  );
+  logger.info('🚀 Grail Hunter actor started - Phase 4.1: Beta Platforms (Mercari + OfferUp)');
 
   try {
     const rawInput = await Actor.getInput();
@@ -58,7 +56,7 @@ Actor.main(async () => {
       enableStockX: input.enableStockX,
     });
 
-    const scraperManager = new ScraperManager(runtimePlatformConfigs);
+    const scraperManager = new ScraperManager(runtimePlatformConfigs, input);
     const normalizer = new DataNormalizer();
     const parser = new SneakerParser();
     const filter = new ListingFilter();

--- a/src/scrapers/manager.js
+++ b/src/scrapers/manager.js
@@ -8,13 +8,16 @@ import { EbayScraper } from './ebay.js';
 import { StockXScraper } from './stockx.js';
 import { DepopScraper } from './depop.js';
 import { PoshmarkScraper } from './poshmark.js';
+import { MercariScraper } from './mercari.js';
+import { OfferUpScraper } from './offerup.js';
 import { PLATFORM_CONFIGS } from '../config/platforms.js';
 import { PlatformScrapingError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
 
 export class ScraperManager {
-  constructor(platformConfigs = PLATFORM_CONFIGS) {
+  constructor(platformConfigs = PLATFORM_CONFIGS, userInput = {}) {
     this.platformConfigs = platformConfigs;
+    this.userInput = userInput; // Store user input for beta platform toggles
     this.scrapers = {};
     this.initializeScrapers();
   }
@@ -44,7 +47,28 @@ export class ScraperManager {
       this.scrapers.poshmark = new PoshmarkScraper(this.platformConfigs.poshmark);
     }
 
-    logger.info('Initialized scrapers', { platforms: Object.keys(this.scrapers) });
+    // Phase 4.1: Beta Platforms (Higher Risk)
+    // Beta platforms require explicit opt-in via betaPlatformsEnabled + per-platform toggles
+    const betaPlatformsEnabled = this.userInput.betaPlatformsEnabled === true;
+
+    if (betaPlatformsEnabled && this.userInput.enableMercari === true) {
+      this.scrapers.mercari = new MercariScraper(this.platformConfigs.mercari);
+      logger.warn(
+        '🧪 Mercari scraper enabled (BETA) - Expect higher failure rates and anti-bot blocking'
+      );
+    }
+
+    if (betaPlatformsEnabled && this.userInput.enableOfferUp === true) {
+      this.scrapers.offerup = new OfferUpScraper(this.platformConfigs.offerup);
+      logger.warn(
+        '🧪 OfferUp scraper enabled (BETA) - Expect higher failure rates, Cloudflare challenges, and slower scraping'
+      );
+    }
+
+    logger.info('Initialized scrapers', {
+      platforms: Object.keys(this.scrapers),
+      betaPlatformsEnabled,
+    });
   }
 
   /**

--- a/src/scrapers/mercari.js
+++ b/src/scrapers/mercari.js
@@ -1,0 +1,143 @@
+/**
+ * Mercari Scraper
+ * Orchestrates the jupri/mercari-scraper Apify actor
+ * Part of Phase 4.1: Beta Platforms
+ *
+ * WARNING: This is a BETA platform with higher risk of blocking and failures.
+ * The underlying actor may be unreliable and under maintenance.
+ */
+
+import { Actor } from 'apify';
+import { BaseScraper } from './base.js';
+import { ActorCallError } from '../utils/errors.js';
+import { logger } from '../utils/logger.js';
+
+export class MercariScraper extends BaseScraper {
+  /**
+   * Scrape Mercari listings
+   * @param {object} searchParams - Search parameters
+   * @returns {Promise<Array>} Raw listings
+   */
+  async scrape(searchParams) {
+    logger.info('Starting Mercari scraping (BETA)', {
+      keywords: searchParams.keywords,
+      maxResults: searchParams.maxResults,
+      riskLevel: 'medium-high',
+      betaPlatform: true,
+    });
+
+    // Get actor ID from config with fallback
+    const actorId = this.config.actorId || 'jupri/mercari-scraper';
+
+    // Apply strict limits for beta platform
+    const maxResults = Math.min(searchParams.maxResults || 30, this.config.maxResults || 30);
+
+    try {
+      // Build search input for Mercari actor
+      // Based on jupri/mercari-scraper input schema
+      const input = {
+        searchKeywords: searchParams.keywords,
+        maxItems: maxResults,
+        proxyConfiguration: searchParams.proxyConfig || {
+          useApifyProxy: true,
+          apifyProxyGroups: ['RESIDENTIAL'],
+        },
+      };
+
+      logger.debug(`Calling ${actorId} actor (BETA)`, { input });
+
+      // Apply timeout for beta platform
+      const timeout = this.config.timeoutMs || 120000; // 2 minutes
+      const run = await Actor.call(actorId, input, {
+        timeoutSecs: Math.floor(timeout / 1000),
+      });
+
+      if (!run) {
+        const error = new ActorCallError(
+          actorId,
+          'Actor call returned null (BETA platform may be unstable)'
+        );
+        error.recoverable = true;
+        throw error;
+      }
+
+      logger.info('Mercari actor run finished (BETA)', {
+        runId: run.id,
+        status: run.status,
+        betaPlatform: true,
+      });
+
+      if (run.status !== 'SUCCEEDED') {
+        const error = new ActorCallError(
+          actorId,
+          `Actor run failed with status: ${run.status} (BETA platform - expect occasional failures)`
+        );
+        error.recoverable = true;
+        throw error;
+      }
+
+      // Fetch all results from the dataset with pagination
+      const dataset = await Actor.apifyClient.dataset(run.defaultDatasetId);
+      const allItems = [];
+      let offset = 0;
+      const limit = 1000;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const page = await dataset.listItems({ limit, offset });
+        if (page?.items?.length) allItems.push(...page.items);
+        if (!page?.items?.length || page.items.length < limit) break;
+        offset += limit;
+      }
+
+      logger.info(`Scraped ${allItems.length} listings from Mercari (BETA)`, {
+        betaPlatform: true,
+        riskLevel: 'medium-high',
+      });
+
+      return allItems;
+    } catch (error) {
+      logger.error('Mercari scraping failed (BETA - expected behavior)', {
+        error: error.message,
+        betaPlatform: true,
+        riskLevel: 'medium-high',
+        recoverable: true,
+      });
+
+      // Mark error as recoverable for graceful degradation
+      if (!error.recoverable) {
+        error.recoverable = true;
+      }
+
+      // If already an ActorCallError, just rethrow it with recoverable flag
+      if (error instanceof ActorCallError) {
+        throw error;
+      }
+
+      // Otherwise wrap it
+      const wrappedError = new ActorCallError(actorId, error.message, error);
+      wrappedError.recoverable = true;
+      throw wrappedError;
+    }
+  }
+
+  /**
+   * Build search URLs from keywords
+   * @param {Array} keywords - Search keywords
+   * @returns {Array} Search queries for Mercari
+   */
+  buildSearchUrls(keywords) {
+    // Mercari actor expects search keywords, not URLs
+    // Return keywords as-is for compatibility with base interface
+    return keywords.map((keyword) => keyword);
+  }
+
+  /**
+   * Validate Mercari scraper configuration
+   */
+  validate() {
+    super.validate();
+    // actorId is optional; scrape() falls back to 'jupri/mercari-scraper' when not provided
+    logger.warn('⚠️  Mercari scraper is BETA - expect higher failure rates and anti-bot blocking');
+  }
+}

--- a/src/scrapers/offerup.js
+++ b/src/scrapers/offerup.js
@@ -1,0 +1,157 @@
+/**
+ * OfferUp Scraper
+ * Orchestrates the igolaizola/offerup-scraper Apify actor
+ * Part of Phase 4.1: Beta Platforms
+ *
+ * WARNING: This is a BETA platform with higher risk of blocking and failures.
+ * OfferUp uses Cloudflare protection and requires browser automation, which is slower.
+ * Requires a US ZIP code for location-based search.
+ */
+
+import { Actor } from 'apify';
+import { BaseScraper } from './base.js';
+import { ActorCallError } from '../utils/errors.js';
+import { logger } from '../utils/logger.js';
+
+export class OfferUpScraper extends BaseScraper {
+  /**
+   * Scrape OfferUp listings
+   * @param {object} searchParams - Search parameters
+   * @returns {Promise<Array>} Raw listings
+   */
+  async scrape(searchParams) {
+    logger.info('Starting OfferUp scraping (BETA)', {
+      keywords: searchParams.keywords,
+      maxResults: searchParams.maxResults,
+      riskLevel: 'medium-high',
+      betaPlatform: true,
+    });
+
+    // Get actor ID from config with fallback
+    const actorId = this.config.actorId || 'igolaizola/offerup-scraper';
+
+    // Apply strict limits for beta platform
+    const maxResults = Math.min(searchParams.maxResults || 30, this.config.maxResults || 30);
+
+    // OfferUp requires ZIP code for location-based search
+    const zipCode = searchParams.zipCode || '10001'; // Default to NYC if not provided
+    if (!searchParams.zipCode) {
+      logger.warn('No ZIP code provided for OfferUp search, defaulting to 10001 (NYC)', {
+        betaPlatform: true,
+      });
+    }
+
+    try {
+      // Build search input for OfferUp actor
+      // Based on igolaizola/offerup-scraper input schema
+      const input = {
+        query: searchParams.keywords.join(' '), // Combine keywords
+        zipCode,
+        maxItems: maxResults,
+        fetchDetails: true, // Get full listing details
+        proxyConfiguration: searchParams.proxyConfig || {
+          useApifyProxy: true,
+          apifyProxyGroups: ['RESIDENTIAL'],
+        },
+      };
+
+      logger.debug(`Calling ${actorId} actor (BETA)`, { input });
+
+      // Apply timeout for beta platform (browser automation is slower)
+      const timeout = this.config.timeoutMs || 180000; // 3 minutes
+      const run = await Actor.call(actorId, input, {
+        timeoutSecs: Math.floor(timeout / 1000),
+      });
+
+      if (!run) {
+        const error = new ActorCallError(
+          actorId,
+          'Actor call returned null (BETA platform may be unstable)'
+        );
+        error.recoverable = true;
+        throw error;
+      }
+
+      logger.info('OfferUp actor run finished (BETA)', {
+        runId: run.id,
+        status: run.status,
+        betaPlatform: true,
+      });
+
+      if (run.status !== 'SUCCEEDED') {
+        const error = new ActorCallError(
+          actorId,
+          `Actor run failed with status: ${run.status} (BETA platform - expect occasional failures)`
+        );
+        error.recoverable = true;
+        throw error;
+      }
+
+      // Fetch all results from the dataset with pagination
+      const dataset = await Actor.apifyClient.dataset(run.defaultDatasetId);
+      const allItems = [];
+      let offset = 0;
+      const limit = 1000;
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const page = await dataset.listItems({ limit, offset });
+        if (page?.items?.length) allItems.push(...page.items);
+        if (!page?.items?.length || page.items.length < limit) break;
+        offset += limit;
+      }
+
+      logger.info(`Scraped ${allItems.length} listings from OfferUp (BETA)`, {
+        betaPlatform: true,
+        riskLevel: 'medium-high',
+        zipCode,
+      });
+
+      return allItems;
+    } catch (error) {
+      logger.error('OfferUp scraping failed (BETA - expected behavior)', {
+        error: error.message,
+        betaPlatform: true,
+        riskLevel: 'medium-high',
+        recoverable: true,
+      });
+
+      // Mark error as recoverable for graceful degradation
+      if (!error.recoverable) {
+        error.recoverable = true;
+      }
+
+      // If already an ActorCallError, just rethrow it with recoverable flag
+      if (error instanceof ActorCallError) {
+        throw error;
+      }
+
+      // Otherwise wrap it
+      const wrappedError = new ActorCallError(actorId, error.message, error);
+      wrappedError.recoverable = true;
+      throw wrappedError;
+    }
+  }
+
+  /**
+   * Build search URLs from keywords
+   * @param {Array} keywords - Search keywords
+   * @returns {Array} Search queries for OfferUp
+   */
+  buildSearchUrls(keywords) {
+    // OfferUp actor expects a single query string, not URLs
+    // Return keywords as-is for compatibility with base interface
+    return keywords.map((keyword) => keyword);
+  }
+
+  /**
+   * Validate OfferUp scraper configuration
+   */
+  validate() {
+    super.validate();
+    // actorId is optional; scrape() falls back to 'igolaizola/offerup-scraper' when not provided
+    logger.warn(
+      '⚠️  OfferUp scraper is BETA - expect higher failure rates, Cloudflare challenges, and slower scraping (browser automation)'
+    );
+  }
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -226,6 +226,32 @@ export function validateInput(input) {
       throw new ValidationError('minSellerReviewCount must be between 0 and 100000');
     }
   }
+
+  // Phase 4.1: Beta platform toggle validations
+  if (input.betaPlatformsEnabled !== undefined && typeof input.betaPlatformsEnabled !== 'boolean') {
+    throw new ValidationError('betaPlatformsEnabled must be a boolean');
+  }
+
+  if (input.enableMercari !== undefined && typeof input.enableMercari !== 'boolean') {
+    throw new ValidationError('enableMercari must be a boolean');
+  }
+
+  if (input.enableOfferUp !== undefined && typeof input.enableOfferUp !== 'boolean') {
+    throw new ValidationError('enableOfferUp must be a boolean');
+  }
+
+  // Validate beta platform precedence rules
+  if (input.enableMercari === true && input.betaPlatformsEnabled !== true) {
+    throw new ValidationError(
+      'enableMercari requires betaPlatformsEnabled to be true. Beta platforms must be explicitly enabled.'
+    );
+  }
+
+  if (input.enableOfferUp === true && input.betaPlatformsEnabled !== true) {
+    throw new ValidationError(
+      'enableOfferUp requires betaPlatformsEnabled to be true. Beta platforms must be explicitly enabled.'
+    );
+  }
 }
 
 /**

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -306,5 +306,10 @@ export function normalizeInput(input) {
     requireOGAll: input.requireOGAll === true,
     minSellerRating: input.minSellerRating !== undefined ? input.minSellerRating : 0,
     minSellerReviewCount: input.minSellerReviewCount !== undefined ? input.minSellerReviewCount : 0,
+    // Phase 4.1: Beta platform toggles
+    betaPlatformsEnabled: input.betaPlatformsEnabled === true,
+    enableMercari: input.enableMercari === true,
+    enableOfferUp: input.enableOfferUp === true,
+    zipCode: input.zipCode || null,
   };
 }

--- a/tests/integration/mercari_scraper.test.js
+++ b/tests/integration/mercari_scraper.test.js
@@ -119,8 +119,10 @@ describe('MercariScraper (mocked Apify integration)', () => {
 
     const scraper = new MercariScraper(config);
 
-    await expect(scraper.scrape(defaultParams)).rejects.toThrow(ActorCallError);
-    await expect(scraper.scrape(defaultParams)).rejects.toThrow(/failed with status: FAILED/);
+    const error = await scraper.scrape(defaultParams).catch((e) => e);
+    expect(error).toBeInstanceOf(ActorCallError);
+    expect(error.message).toMatch(/failed with status: FAILED/);
+    expect(error.recoverable).toBe(true);
   });
 
   it('should handle null actor response', async () => {

--- a/tests/integration/mercari_scraper.test.js
+++ b/tests/integration/mercari_scraper.test.js
@@ -1,0 +1,159 @@
+/**
+ * Integration test for MercariScraper using mocked Apify API responses
+ * Phase 4.1: Beta Platforms
+ */
+
+import { jest } from '@jest/globals';
+import { ActorCallError } from '../../src/utils/errors.js';
+
+const mockMercariListings = [
+  {
+    id: 'merc123',
+    title: 'Air Jordan 1 Retro High OG Chicago',
+    price: 280,
+    priceAmount: 280,
+    description: 'Brand new with tags, never worn',
+    brand: 'Nike',
+    size: '11',
+    condition: 'new',
+    url: 'https://mercari.com/us/item/merc123',
+    sellerName: 'sneakerdealer',
+    sellerRating: 4.9,
+    sellerReviewCount: 200,
+    image: 'https://mercari.com/images/merc123.jpg',
+  },
+  {
+    id: 'merc456',
+    title: 'Nike Dunk Low Panda',
+    price: 180,
+    description: 'Like new condition',
+    size: '10.5',
+    condition: 'like new',
+    productUrl: 'https://mercari.com/us/item/merc456',
+    photo: 'https://mercari.com/images/merc456.jpg',
+  },
+];
+
+const mockActorCall = jest.fn();
+const mockDatasetListItems = jest.fn();
+const mockApifyClientDataset = jest.fn(() => ({ listItems: mockDatasetListItems }));
+
+jest.unstable_mockModule('apify', () => ({
+  Actor: {
+    call: mockActorCall,
+    apifyClient: {
+      dataset: mockApifyClientDataset,
+    },
+  },
+}));
+
+let MercariScraper;
+
+beforeAll(async () => {
+  ({ MercariScraper } = await import('../../src/scrapers/mercari.js'));
+});
+
+describe('MercariScraper (mocked Apify integration)', () => {
+  const defaultParams = {
+    keywords: ['Air Jordan 1', 'Nike Dunk'],
+    maxResults: 30,
+    proxyConfig: {
+      useApifyProxy: true,
+      apifyProxyGroups: ['RESIDENTIAL'],
+    },
+  };
+
+  const config = {
+    name: 'Mercari',
+    type: 'orchestrated',
+    actorId: 'jupri/mercari-scraper',
+    rateLimit: 50,
+    maxResults: 30,
+    timeoutMs: 120000,
+    riskLevel: 'medium-high',
+    isBeta: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully scrape Mercari listings', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-123',
+      status: 'SUCCEEDED',
+      defaultDatasetId: 'dataset-123',
+    });
+
+    mockDatasetListItems.mockResolvedValueOnce({
+      items: mockMercariListings,
+    });
+
+    const scraper = new MercariScraper(config);
+    const results = await scraper.scrape(defaultParams);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].id).toBe('merc123');
+    expect(results[0].title).toContain('Air Jordan 1');
+    expect(results[1].id).toBe('merc456');
+
+    expect(mockActorCall).toHaveBeenCalledWith(
+      'jupri/mercari-scraper',
+      expect.objectContaining({
+        searchKeywords: defaultParams.keywords,
+        maxItems: 30,
+        proxyConfiguration: defaultParams.proxyConfig,
+      }),
+      expect.objectContaining({
+        timeoutSecs: 120,
+      })
+    );
+  });
+
+  it('should handle actor call failure gracefully (BETA platform)', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-456',
+      status: 'FAILED',
+      defaultDatasetId: 'dataset-456',
+    });
+
+    const scraper = new MercariScraper(config);
+
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(ActorCallError);
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(/failed with status: FAILED/);
+  });
+
+  it('should handle null actor response', async () => {
+    mockActorCall.mockResolvedValueOnce(null);
+
+    const scraper = new MercariScraper(config);
+
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(ActorCallError);
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(/Actor call returned null/);
+  });
+
+  it('should apply strict maxResults limit for beta platform', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-789',
+      status: 'SUCCEEDED',
+      defaultDatasetId: 'dataset-789',
+    });
+
+    mockDatasetListItems.mockResolvedValueOnce({
+      items: [],
+    });
+
+    const scraper = new MercariScraper(config);
+
+    // Try to request 100 items, but beta platform should cap at 30
+    await scraper.scrape({ ...defaultParams, maxResults: 100 });
+
+    expect(mockActorCall).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        maxItems: 30, // Capped at beta platform limit
+      }),
+      expect.any(Object)
+    );
+  });
+});

--- a/tests/integration/offerup_scraper.test.js
+++ b/tests/integration/offerup_scraper.test.js
@@ -163,8 +163,10 @@ describe('OfferUpScraper (mocked Apify integration)', () => {
 
     const scraper = new OfferUpScraper(config);
 
-    await expect(scraper.scrape(defaultParams)).rejects.toThrow(ActorCallError);
-    await expect(scraper.scrape(defaultParams)).rejects.toThrow(/failed with status: FAILED/);
+    const error = await scraper.scrape(defaultParams).catch((e) => e);
+    expect(error).toBeInstanceOf(ActorCallError);
+    expect(error.message).toMatch(/failed with status: FAILED/);
+    expect(error.recoverable).toBe(true);
   });
 
   it('should apply strict maxResults limit for beta platform', async () => {
@@ -197,11 +199,8 @@ describe('OfferUpScraper (mocked Apify integration)', () => {
 
     const scraper = new OfferUpScraper(config);
 
-    try {
-      await scraper.scrape(defaultParams);
-    } catch (error) {
-      expect(error).toBeInstanceOf(ActorCallError);
-      expect(error.recoverable).toBe(true); // Should be marked as recoverable
-    }
+    const error = await scraper.scrape(defaultParams).catch((e) => e);
+    expect(error).toBeInstanceOf(ActorCallError);
+    expect(error.recoverable).toBe(true); // Should be marked as recoverable
   });
 });

--- a/tests/integration/offerup_scraper.test.js
+++ b/tests/integration/offerup_scraper.test.js
@@ -1,0 +1,207 @@
+/**
+ * Integration test for OfferUpScraper using mocked Apify API responses
+ * Phase 4.1: Beta Platforms
+ */
+
+import { jest } from '@jest/globals';
+import { ActorCallError } from '../../src/utils/errors.js';
+
+const mockOfferUpListings = [
+  {
+    listingId: 'offer123',
+    title: 'Air Jordan 1 Retro High OG Shadow',
+    price: 220,
+    formattedPrice: '$220',
+    description: 'Good condition, worn a few times',
+    size: '10',
+    condition: 'good',
+    url: 'https://offerup.com/item/detail/offer123',
+    image: 'https://offerup.com/photos/offer123.jpg',
+    locationName: 'Los Angeles, CA',
+    _details: {
+      description: 'Good condition, worn a few times. OG box included.',
+      condition: 'good',
+      seller: {
+        name: 'john_doe',
+        rating: 4.7,
+        reviewCount: 85,
+        verified: true,
+      },
+      location: {
+        name: 'Los Angeles, CA',
+        zipCode: '90001',
+      },
+      photos: ['https://offerup.com/photos/offer123.jpg'],
+    },
+  },
+  {
+    listingId: 'offer456',
+    title: 'Yeezy Boost 350 V2 Zebra',
+    price: 300,
+    formattedPrice: '$300',
+    description: 'Brand new, never worn',
+    size: '11.5',
+    condition: 'new',
+    url: 'https://offerup.com/item/detail/offer456',
+    image: 'https://offerup.com/photos/offer456.jpg',
+    locationName: 'New York, NY',
+  },
+];
+
+const mockActorCall = jest.fn();
+const mockDatasetListItems = jest.fn();
+const mockApifyClientDataset = jest.fn(() => ({ listItems: mockDatasetListItems }));
+
+jest.unstable_mockModule('apify', () => ({
+  Actor: {
+    call: mockActorCall,
+    apifyClient: {
+      dataset: mockApifyClientDataset,
+    },
+  },
+}));
+
+let OfferUpScraper;
+
+beforeAll(async () => {
+  ({ OfferUpScraper } = await import('../../src/scrapers/offerup.js'));
+});
+
+describe('OfferUpScraper (mocked Apify integration)', () => {
+  const defaultParams = {
+    keywords: ['Air Jordan 1', 'Yeezy'],
+    maxResults: 30,
+    zipCode: '10001',
+    proxyConfig: {
+      useApifyProxy: true,
+      apifyProxyGroups: ['RESIDENTIAL'],
+    },
+  };
+
+  const config = {
+    name: 'OfferUp',
+    type: 'orchestrated',
+    actorId: 'igolaizola/offerup-scraper',
+    rateLimit: 30,
+    maxResults: 30,
+    timeoutMs: 180000,
+    riskLevel: 'medium-high',
+    isBeta: true,
+    requiresZipCode: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should successfully scrape OfferUp listings with ZIP code', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-123',
+      status: 'SUCCEEDED',
+      defaultDatasetId: 'dataset-123',
+    });
+
+    mockDatasetListItems.mockResolvedValueOnce({
+      items: mockOfferUpListings,
+    });
+
+    const scraper = new OfferUpScraper(config);
+    const results = await scraper.scrape(defaultParams);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].listingId).toBe('offer123');
+    expect(results[0].title).toContain('Air Jordan 1');
+    expect(results[1].listingId).toBe('offer456');
+
+    expect(mockActorCall).toHaveBeenCalledWith(
+      'igolaizola/offerup-scraper',
+      expect.objectContaining({
+        query: 'Air Jordan 1 Yeezy', // Combined keywords
+        zipCode: '10001',
+        maxItems: 30,
+        fetchDetails: true,
+        proxyConfiguration: defaultParams.proxyConfig,
+      }),
+      expect.objectContaining({
+        timeoutSecs: 180, // 3 minutes for browser automation
+      })
+    );
+  });
+
+  it('should default to NYC ZIP code when not provided', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-456',
+      status: 'SUCCEEDED',
+      defaultDatasetId: 'dataset-456',
+    });
+
+    mockDatasetListItems.mockResolvedValueOnce({
+      items: [],
+    });
+
+    const scraper = new OfferUpScraper(config);
+    const paramsWithoutZip = { ...defaultParams };
+    delete paramsWithoutZip.zipCode;
+
+    await scraper.scrape(paramsWithoutZip);
+
+    expect(mockActorCall).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        zipCode: '10001', // Default to NYC
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('should handle actor call failure gracefully (BETA platform)', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-789',
+      status: 'FAILED',
+      defaultDatasetId: 'dataset-789',
+    });
+
+    const scraper = new OfferUpScraper(config);
+
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(ActorCallError);
+    await expect(scraper.scrape(defaultParams)).rejects.toThrow(/failed with status: FAILED/);
+  });
+
+  it('should apply strict maxResults limit for beta platform', async () => {
+    mockActorCall.mockResolvedValueOnce({
+      id: 'run-999',
+      status: 'SUCCEEDED',
+      defaultDatasetId: 'dataset-999',
+    });
+
+    mockDatasetListItems.mockResolvedValueOnce({
+      items: [],
+    });
+
+    const scraper = new OfferUpScraper(config);
+
+    // Try to request 100 items, but beta platform should cap at 30
+    await scraper.scrape({ ...defaultParams, maxResults: 100 });
+
+    expect(mockActorCall).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        maxItems: 30, // Capped at beta platform limit
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('should handle errors as recoverable for graceful degradation', async () => {
+    mockActorCall.mockRejectedValueOnce(new Error('Network timeout'));
+
+    const scraper = new OfferUpScraper(config);
+
+    try {
+      await scraper.scrape(defaultParams);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ActorCallError);
+      expect(error.recoverable).toBe(true); // Should be marked as recoverable
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Implements Phase 4.1: Beta Platforms (Mercari & OfferUp) with comprehensive risk management and failure monitoring.

## Related Issues
Closes #15

## Implementation Details
- ✅ **Mercari scraper** using `jupri/mercari-scraper` actor (Pattern A orchestration)
- ✅ **OfferUp scraper** using `igolaizola/offerup-scraper` actor (Pattern A orchestration)
- ✅ **Double opt-in system**: `betaPlatformsEnabled` + `enableMercari`/`enableOfferUp` toggles
- ✅ **Strict limits**: 30 max results, 2 retries, 2-3 min timeouts
- ✅ **Graceful degradation**: All errors marked as recoverable for multi-platform resilience
- ✅ **Comprehensive failure monitoring**: Per-platform stats, failure rates, threshold warnings
- ✅ **Risk management**: `medium-high` risk level, beta flags, Cloudflare/anti-bot warnings

## Key Features

### Beta Platform Architecture
- Global toggle `betaPlatformsEnabled` prevents accidental activation
- Per-platform toggles `enableMercari` and `enableOfferUp` for granular control
- Validation enforces both global and platform-specific toggles must be true
- ScraperManager conditionally initializes scrapers based on user input

### Failure Monitoring (COVERAGE_ROADMAP.md requirement)
- **Per-platform tracking**: `scraped`, `normalized`, `filtered`, `new`, `priceDrops`, `errors`, `failed`, `errorMessage`
- **Beta health metrics**: `betaPlatformsUsed`, `betaPlatformsFailed`, `betaFailureRate`
- **Threshold warnings**: 
  - `betaFailureRate > 50%` → `HIGH_FAILURE_RATE` warning + actionable recommendations
  - `betaFailureRate > 25%` → `ELEVATED_FAILURE_RATE` monitoring alert
- **Recommendations**: Disable beta platforms, check actor status, verify proxy config

### Platform-Specific Normalizers
- `normalizeMercari()`: Maps Mercari-specific fields (`id`, `priceAmount`, `sellerRating`, etc.)
- `normalizeOfferUp()`: Handles OfferUp's `_details` structure and location data
- Condition mapping: Platform conditions → standardized enums (`new_in_box`, `used_like_new`, etc.)

### Enhanced Input Schema
- Added `betaPlatformsEnabled`, `enableMercari`, `enableOfferUp` with detailed descriptions
- Added `"mercari"` and `"offerup"` to platforms enum with 🧪 BETA labels
- Validation with precedence rules (beta toggles require global toggle)

## Testing
```bash
npm test
# Test Suites: 23 passed, 23 total
# Tests:       182 passed, 182 total
# Coverage:    83.5% (maintained)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two opt-in beta marketplaces: Mercari and OfferUp (per‑platform and global toggles)
  * OfferUp supports ZIP code location searches; beta platforms have conservative result caps and health warnings
  * Platform health tracking now reports beta failure rates and recommendations

* **Documentation**
  * README and roadmap updated to reflect Phase 4.1 completion and opt‑in requirements

* **Tests**
  * New integration and unit tests covering Mercari and OfferUp beta flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->